### PR TITLE
Add constants loader and hash tracking

### DIFF
--- a/constants.yml
+++ b/constants.yml
@@ -1,0 +1,5 @@
+# Default constants with clause citations
+compressive_strength_increment: 100   # ACI 318-19 §19.2.3
+prestress_loss_factor: 0.60           # PTI DC10.5-15 §5.4
+deflection_multiplier: 2.0            # ACI 24.2.4.1
+minimum_average_prestress: 125        # PTI DC10.5 §6.2

--- a/src/app/constants_loader.py
+++ b/src/app/constants_loader.py
@@ -1,0 +1,36 @@
+from pathlib import Path
+
+DEFAULTS_PATH = Path(__file__).resolve().parents[2] / 'constants.yml'
+
+
+def _parse_constants(path: Path) -> dict:
+    constants = {}
+    with open(path, 'r', encoding='utf-8') as f:
+        for line in f:
+            # remove comments
+            line = line.split('#', 1)[0].strip()
+            if not line:
+                continue
+            if ':' not in line:
+                continue
+            key, value = line.split(':', 1)
+            key = key.strip()
+            value = value.strip()
+            try:
+                if '.' in value:
+                    value = float(value)
+                else:
+                    value = int(value)
+            except ValueError:
+                pass
+            constants[key] = value
+    return constants
+
+
+def load_constants(overrides=None):
+    """Load constants and merge any user overrides."""
+    defaults = _parse_constants(DEFAULTS_PATH)
+    overrides = overrides or {}
+    merged = defaults.copy()
+    merged.update(overrides)
+    return merged, defaults

--- a/src/app/main.py
+++ b/src/app/main.py
@@ -1,0 +1,14 @@
+from .optimize import optimize
+from .results import display_results
+
+
+def main() -> None:
+    # example inputs
+    inputs = {'fc': 6000, 'span': 30}
+    overrides = {}
+    result = optimize(inputs, overrides)
+    display_results(result)
+
+
+if __name__ == '__main__':
+    main()

--- a/src/app/optimize.py
+++ b/src/app/optimize.py
@@ -1,0 +1,43 @@
+import json
+import hashlib
+import subprocess
+from typing import Dict, Tuple
+
+from .constants_loader import load_constants
+
+
+def git_commit_hash() -> str:
+    """Return the current git commit hash."""
+    try:
+        commit = subprocess.check_output(
+            ['git', 'rev-parse', 'HEAD'], encoding='utf-8'
+        ).strip()
+    except Exception:
+        commit = 'unknown'
+    return commit
+
+
+def compute_inputs_hash(inputs: Dict, constants: Dict, commit: str) -> str:
+    """Compute SHA256 hash of inputs, constants and commit."""
+    data = {
+        'inputs': inputs,
+        'constants': constants,
+        'commit': commit,
+    }
+    payload = json.dumps(data, sort_keys=True).encode('utf-8')
+    return hashlib.sha256(payload).hexdigest()
+
+
+def optimize(inputs: Dict, overrides: Dict | None = None) -> Dict:
+    """Dummy optimisation routine returning hash and merged constants."""
+    merged, defaults = load_constants(overrides)
+    commit = git_commit_hash()
+    run_hash = compute_inputs_hash(inputs, merged, commit)
+    # placeholder for real optimisation
+    return {
+        'inputs': inputs,
+        'constants': merged,
+        'defaults': defaults,
+        'commit': commit,
+        'run_hash': run_hash,
+    }

--- a/src/app/results.py
+++ b/src/app/results.py
@@ -1,0 +1,14 @@
+from typing import Dict
+
+
+def display_results(result: Dict) -> None:
+    """Print optimisation results including hash and constants."""
+    print(f"Run hash: {result['run_hash']}")
+    print(f"Git commit: {result['commit']}")
+    print("\nConstants used:")
+    for key, default_val in result['defaults'].items():
+        val = result['constants'][key]
+        if val != default_val:
+            print(f"- {key}: {val} (override, default {default_val})")
+        else:
+            print(f"- {key}: {val}")

--- a/tests/test_constants.py
+++ b/tests/test_constants.py
@@ -1,0 +1,14 @@
+import sys, pathlib; sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[1] / "src"))
+from app.constants_loader import load_constants
+
+
+def test_load_defaults():
+    merged, defaults = load_constants()
+    assert merged == defaults
+    assert 'compressive_strength_increment' in merged
+
+
+def test_overrides():
+    merged, defaults = load_constants({'deflection_multiplier': 3.0})
+    assert merged['deflection_multiplier'] == 3.0
+    assert defaults['deflection_multiplier'] == 2.0

--- a/tests/test_hash.py
+++ b/tests/test_hash.py
@@ -1,0 +1,16 @@
+import sys, pathlib; sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[1] / "src"))
+from app.optimize import optimize, compute_inputs_hash, git_commit_hash
+
+
+def test_hash_consistency():
+    inputs = {'fc': 6000}
+    result1 = optimize(inputs)
+    result2 = optimize(inputs)
+    assert result1['run_hash'] == result2['run_hash']
+
+
+def test_hash_changes_with_override():
+    inputs = {'fc': 6000}
+    result1 = optimize(inputs)
+    result2 = optimize(inputs, {'deflection_multiplier': 3.0})
+    assert result1['run_hash'] != result2['run_hash']


### PR DESCRIPTION
## Summary
- set up `constants.yml` with default values and code clause citations
- load constants and allow overrides without needing PyYAML
- compute an inputs hash using constants and the git commit
- show the hash and which constants were overridden
- add tests for loading and hashing

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_685b757d70b08325997e887ff1fd6dde