### PR TITLE
Add cost model implementation with tests

### DIFF
--- a/solver/cost.py
+++ b/solver/cost.py
@@ -1,0 +1,59 @@
+from dataclasses import dataclass
+from typing import List
+
+STEEL_DENSITY = 490  # lb/ft^3
+STRAND_UNIT_WEIGHT = 0.522  # lb/ft
+
+@dataclass
+class Beam:
+    bw: float      # in
+    depth: float   # in
+    length: float  # ft
+    tendons: int
+    tendon_length: float  # ft per tendon
+
+@dataclass
+class Materials:
+    rebar_cost: float       # $/lb
+    strand_cost: float      # $/lb
+    formwork_slab: float    # $/ft^2
+    formwork_beam: float    # $/ft^2
+    pump_cost: float        # $/yd^3
+
+
+def concrete_unit_price(fc: int) -> float:
+    base = 220
+    if fc <= 8_500:
+        add = (fc - 5_000) // 700 * 10
+    else:
+        add = 50 + (fc - 8_500) // 1_200 * 18
+    return base + add
+
+@dataclass
+class Design:
+    fc: int
+    slab_area: float  # ft^2
+    slab_thick: float  # in
+    rho: float
+    beams: List[Beam]
+
+
+def takeoffs(d: Design):
+    vol_slab = d.slab_area * d.slab_thick / 12 / 27
+    vol_beam = sum(b.bw * b.depth * b.length for b in d.beams) / 12**3 / 27
+    wt_rebar = d.rho * 12 * d.slab_thick / 12 * d.slab_area * STEEL_DENSITY
+    wt_pt = sum(b.tendons * b.tendon_length for b in d.beams) * STRAND_UNIT_WEIGHT
+    form_slab_area = d.slab_area
+    form_beam_area = sum((2 * b.depth / 12 + b.bw / 12) * b.length for b in d.beams)
+    return vol_slab, vol_beam, wt_rebar, wt_pt, form_slab_area, form_beam_area
+
+
+def cost_of(d: Design, m: Materials) -> float:
+    vol_slab, vol_beam, wt_rebar, wt_pt, a_slab, a_beam = takeoffs(d)
+    unit_price = concrete_unit_price(d.fc)
+    conc_cost = (vol_slab + vol_beam) * unit_price
+    rebar_cost = wt_rebar * m.rebar_cost
+    pt_cost = wt_pt * m.strand_cost
+    form_cost = a_slab * m.formwork_slab + a_beam * m.formwork_beam
+    pump_cost = (vol_slab + vol_beam) * m.pump_cost
+    return conc_cost + rebar_cost + pt_cost + form_cost + pump_cost

--- a/tests/test_cost.py
+++ b/tests/test_cost.py
@@ -1,0 +1,20 @@
+from solver.cost import Beam, Design, Materials, cost_of
+
+
+def test_cost_example():
+    design = Design(
+        fc=6000,
+        slab_area=1000,
+        slab_thick=6,
+        rho=0.005,
+        beams=[Beam(bw=12, depth=24, length=30, tendons=4, tendon_length=30)],
+    )
+    materials = Materials(
+        rebar_cost=1.2,
+        strand_cost=2.0,
+        formwork_slab=2.0,
+        formwork_beam=3.0,
+        pump_cost=15.0,
+    )
+    cost = cost_of(design, materials)
+    assert abs(cost - 24797.68740740741) < 1e-6


### PR DESCRIPTION
## Summary
- implement a basic cost model covering beam volume, formwork and pumping
- compute PT strand weight using tendon length and quantity
- include unit test for cost calculations

## Testing
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_685b7563022483258ca391c35d879afa